### PR TITLE
fix return types and url string for HTTP methods in account, booking, and lodging services

### DIFF
--- a/angular/src/app/layout/footer/footer.component.html
+++ b/angular/src/app/layout/footer/footer.component.html
@@ -11,6 +11,7 @@
             <i aria-hidden="true" class="{{ link.icon }}"></i>
           </span>
           {{ link.text }}
+          <p>hey i changed something</p>
         </a>
       </div>
     </nav>

--- a/angular/src/app/layout/footer/footer.component.html
+++ b/angular/src/app/layout/footer/footer.component.html
@@ -11,7 +11,6 @@
             <i aria-hidden="true" class="{{ link.icon }}"></i>
           </span>
           {{ link.text }}
-          <p>hey i changed something</p>
         </a>
       </div>
     </nav>

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -48,6 +48,6 @@ describe('PaymentComponent', () => {
 
     component.addCard(mockPayment);
 
-    expect(component.payments[1]).toEqual(mockPayment);
+    expect(component.payments.length).toEqual(2);
   });
 });

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -13,6 +13,14 @@ describe('PaymentComponent', () => {
       securityCode: '',
     },
   ];
+  const mockPayment = {
+    accountId: 'string',
+    id: 'string',
+    cardExpirationDate: '2020-08-01',
+    cardName: 'string',
+    cardNumber: 'string',
+    securityCode: '111',
+  } as PostPayment;
   let component: PaymentComponent;
   let fixture: ComponentFixture<PaymentComponent>;
 
@@ -37,17 +45,7 @@ describe('PaymentComponent', () => {
   });
 
   it('should add card', () => {
-    const mockPayment = {
-      accountId: 'string',
-      id: 'string',
-      cardExpirationDate: '2020-08-01',
-      cardName: 'string',
-      cardNumber: 'string',
-      securityCode: '111',
-    } as PostPayment;
-
     component.addCard(mockPayment);
-
-    expect(component.payments.length).toEqual(2);
+    expect(component.payments[1]).toEqual(mockPayment);
   });
 });

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -1,6 +1,7 @@
-import { async, ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, tick } from '@angular/core/testing';
 import { PaymentComponent } from './payment.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PostPayment } from 'src/app/data/payment.model';
 
 describe('PaymentComponent', () => {
   const payments = [
@@ -33,5 +34,22 @@ describe('PaymentComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should add card', () => {
+    const mockPayment = {
+      accountId: 'string',
+      id: 'string',
+      cardExpirationDate: '2020-08-01',
+      cardName: 'string',
+      cardNumber: 'string',
+      securityCode: '111',
+    } as PostPayment;
+
+    component.addCard(mockPayment);
+
+    tick();
+
+    expect(payments[1]).toEqual(mockPayment);
   });
 });

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -46,6 +46,9 @@ describe('PaymentComponent', () => {
 
   it('should add card', () => {
     component.addCard(mockPayment);
+
+    fixture.detectChanges();
+
     expect(component.payments[1]).toEqual(mockPayment);
   });
 });

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -36,7 +36,7 @@ describe('PaymentComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should add card', fakeAsync(() => {
+  it('should add card', () => {
     const mockPayment = {
       accountId: 'string',
       id: 'string',
@@ -48,8 +48,6 @@ describe('PaymentComponent', () => {
 
     component.addCard(mockPayment);
 
-    tick();
-
-    expect(payments[1]).toEqual(mockPayment);
-  }));
+    expect(component.payments[1]).toEqual(mockPayment);
+  });
 });

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -1,7 +1,6 @@
-import { async, ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PaymentComponent } from './payment.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { PostPayment } from 'src/app/data/payment.model';
 
 describe('PaymentComponent', () => {
   const payments = [
@@ -13,14 +12,6 @@ describe('PaymentComponent', () => {
       securityCode: '',
     },
   ];
-  const mockPayment = {
-    accountId: 'string',
-    id: 'string',
-    cardExpirationDate: '2020-08-01',
-    cardName: 'string',
-    cardNumber: 'string',
-    securityCode: '111',
-  } as PostPayment;
   let component: PaymentComponent;
   let fixture: ComponentFixture<PaymentComponent>;
 
@@ -42,13 +33,5 @@ describe('PaymentComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should add card', () => {
-    component.addCard(mockPayment);
-
-    fixture.detectChanges();
-
-    expect(component.payments[1]).toEqual(mockPayment);
   });
 });

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { PaymentComponent } from './payment.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed, tick } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
 import { PaymentComponent } from './payment.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { PostPayment } from 'src/app/data/payment.model';
@@ -36,7 +36,7 @@ describe('PaymentComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should add card', () => {
+  it('should add card', fakeAsync(() => {
     const mockPayment = {
       accountId: 'string',
       id: 'string',
@@ -48,6 +48,8 @@ describe('PaymentComponent', () => {
 
     component.addCard(mockPayment);
 
+    tick();
+
     expect(payments[1]).toEqual(mockPayment);
-  });
+  }));
 });

--- a/angular/src/app/modules/account/payment/payment.component.spec.ts
+++ b/angular/src/app/modules/account/payment/payment.component.spec.ts
@@ -48,8 +48,6 @@ describe('PaymentComponent', () => {
 
     component.addCard(mockPayment);
 
-    tick();
-
     expect(payments[1]).toEqual(mockPayment);
   });
 });

--- a/angular/src/app/modules/account/payment/payment.component.ts
+++ b/angular/src/app/modules/account/payment/payment.component.ts
@@ -21,12 +21,12 @@ export class PaymentComponent {
 
   /**
    * Adds a new set of payment information
-   * @param newCard Payment
+   * @param card Payment
    */
-  addCard(newCard: PostPayment): void {
-    newCard.accountId = this.accountId;
-    this.accountService.postPayment(newCard).subscribe(
-      (e) =>
+  addCard(card: PostPayment): void {
+    card.accountId = this.accountId;
+    this.accountService.postPayment(card).subscribe(
+      (newCard) =>
         this.payments.push({
           id: '',
           cardName: newCard.cardName,

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -101,7 +101,6 @@ describe('AccountService', () => {
 
     tick();
 
-    expect(service.delete).toHaveBeenCalled();
     req = httpTestingController.expectOne('test/0');
     req.flush(JSON.stringify(true));
   }));

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -158,12 +158,12 @@ describe('AccountService', () => {
     } as PostPayment;
 
     service.postPayment(mockPayment).subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(res).toEqual(mockPayment);
     });
 
     tick();
 
     req = httpTestingController.expectOne('test');
-    req.flush(JSON.stringify(true));
+    req.flush(mockPayment);
   }));
 });

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -98,7 +98,7 @@ describe('AccountService', () => {
     let req: TestRequest;
 
     service.delete('0').subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(service.delete).toHaveBeenCalled();
     });
 
     tick();

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -146,14 +146,14 @@ describe('AccountService', () => {
 
   it('should make httpPost request for payments', fakeAsync(() => {
     let req: TestRequest;
-    const mockPayment = {
+    const mockPayment: PostPayment = {
       accountId: 'string',
       id: 'string',
       cardExpirationDate: '2020-08-01',
       cardName: 'string',
       cardNumber: 'string',
       securityCode: '111',
-    } as PostPayment;
+    };
 
     service.postPayment(mockPayment).subscribe((res) => {
       expect(res).toEqual(mockPayment);

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -97,12 +97,11 @@ describe('AccountService', () => {
   it('should make httpDelete request', fakeAsync(() => {
     let req: TestRequest;
 
-    service.delete('0').subscribe((res) => {
-      expect(service.delete).toHaveBeenCalled();
-    });
+    service.delete('0').subscribe();
 
     tick();
 
+    expect(service.delete).toHaveBeenCalled();
     req = httpTestingController.expectOne('test/0');
     req.flush(JSON.stringify(true));
   }));

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -124,13 +124,13 @@ describe('AccountService', () => {
     let req: TestRequest;
 
     service.post(accountMock).subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(res).toEqual(accountMock);
     });
 
     tick();
 
     req = httpTestingController.expectOne('test');
-    req.flush(JSON.stringify(true));
+    req.flush(accountMock);
   }));
 
   it('should make httpPut request', fakeAsync(() => {

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -102,7 +102,7 @@ describe('AccountService', () => {
     tick();
 
     req = httpTestingController.expectOne('test/0');
-    req.flush(JSON.stringify(true));
+    req.flush(null);
   }));
 
   it('should make httpGet request', fakeAsync(() => {

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -84,7 +84,7 @@ export class AccountService {
    * @param payment
    * Represents the _Account Service_ 'post' method for payments
    */
-  postPayment(payment: PostPayment): Observable<boolean> {
-    return this.paymentsUrl$.pipe(concatMap((url) => this.http.post<boolean>(url, payment)));
+  postPayment(payment: PostPayment): Observable<PostPayment> {
+    return this.paymentsUrl$.pipe(concatMap((url) => this.http.post<PostPayment>(url, payment)));
   }
 }

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -42,10 +42,10 @@ export class AccountService {
    *
    * @param id string
    */
-  delete(id: string): Observable<Response> {
+  delete(id: string): Observable<void> {
     return this.accountsUrl$.pipe(
       map((url) => url.concat(`/${id}`)),
-      concatMap((url) => this.http.delete<Response>(url))
+      concatMap((url) => this.http.delete<void>(url))
     );
   }
 

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -42,10 +42,10 @@ export class AccountService {
    *
    * @param id string
    */
-  delete(id: string): void {
-    this.accountsUrl$.pipe(
+  delete(id: string): Observable<Response> {
+    return this.accountsUrl$.pipe(
       map((url) => url.concat(`/${id}`)),
-      concatMap((url) => this.http.delete(url))
+      concatMap((url) => this.http.delete<Response>(url))
     );
   }
 

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -42,10 +42,10 @@ export class AccountService {
    *
    * @param id string
    */
-  delete(id: string): Observable<boolean> {
-    return this.accountsUrl$.pipe(
+  delete(id: string): void {
+    this.accountsUrl$.pipe(
       map((url) => url.concat(`/${id}`)),
-      concatMap((url) => this.http.delete<boolean>(url))
+      concatMap((url) => this.http.delete(url))
     );
   }
 
@@ -66,8 +66,8 @@ export class AccountService {
    *
    * @param account Account
    */
-  post(account: Account): Observable<boolean> {
-    return this.accountsUrl$.pipe(concatMap((url) => this.http.post<boolean>(url, account)));
+  post(account: Account): Observable<Account> {
+    return this.accountsUrl$.pipe(concatMap((url) => this.http.post<Account>(url, account)));
   }
 
   /**

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -90,9 +90,7 @@ describe('BookingService', () => {
   it('should make httpDelete request', fakeAsync(() => {
     let req: TestRequest;
 
-    service.delete('0').subscribe((res) => {
-      expect(service.delete).toHaveBeenCalled();
-    });
+    service.delete('0').subscribe();
 
     tick();
 

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -95,7 +95,7 @@ describe('BookingService', () => {
     tick();
 
     req = httpTestingController.expectOne('test/0');
-    req.flush(JSON.stringify(true));
+    req.flush(null);
   }));
 
   it('should make httpGet request', fakeAsync(() => {

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -125,13 +125,13 @@ describe('BookingService', () => {
     let req: TestRequest;
 
     service.post(bookingMock[0]).subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(res).toEqual(bookingMock[0]);
     });
 
     tick();
 
     req = httpTestingController.expectOne('test');
-    req.flush(JSON.stringify(true));
+    req.flush(bookingMock[0]);
   }));
 
   it('should make httpPut request', fakeAsync(() => {

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -96,7 +96,7 @@ describe('BookingService', () => {
 
     tick();
 
-    req = httpTestingController.expectOne('test?id=0');
+    req = httpTestingController.expectOne('test/0');
     req.flush(JSON.stringify(true));
   }));
 
@@ -115,7 +115,7 @@ describe('BookingService', () => {
     tick();
 
     req = httpTestingController.expectOne('test');
-    reqOne = httpTestingController.expectOne('test?id=0');
+    reqOne = httpTestingController.expectOne('test/0');
 
     req.flush(bookingMock);
     reqOne.flush(bookingMock);

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -97,7 +97,7 @@ describe('BookingService', () => {
     tick();
 
     req = httpTestingController.expectOne('test?id=0');
-    req.flush(status);
+    req.flush(204);
   }));
 
   it('should make httpGet request', fakeAsync(() => {

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -91,13 +91,13 @@ describe('BookingService', () => {
     let req: TestRequest;
 
     service.delete('0').subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(res.status).toBe(204);
     });
 
     tick();
 
     req = httpTestingController.expectOne('test?id=0');
-    req.flush(JSON.stringify(true));
+    req.flush(status);
   }));
 
   it('should make httpGet request', fakeAsync(() => {

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -91,7 +91,7 @@ describe('BookingService', () => {
     let req: TestRequest;
 
     service.delete('0').subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(service.delete).toHaveBeenCalled();
     });
 
     tick();

--- a/angular/src/app/services/booking/booking.service.spec.ts
+++ b/angular/src/app/services/booking/booking.service.spec.ts
@@ -91,13 +91,13 @@ describe('BookingService', () => {
     let req: TestRequest;
 
     service.delete('0').subscribe((res) => {
-      expect(res.status).toBe(204);
+      expect(JSON.parse(res.toString())).toBeTrue();
     });
 
     tick();
 
     req = httpTestingController.expectOne('test?id=0');
-    req.flush(204);
+    req.flush(JSON.stringify(true));
   }));
 
   it('should make httpGet request', fakeAsync(() => {

--- a/angular/src/app/services/booking/booking.service.ts
+++ b/angular/src/app/services/booking/booking.service.ts
@@ -43,9 +43,9 @@ export class BookingService {
    *
    * @param id string
    */
-  delete(id: string): Observable<Response> {
+  delete(id: string): Observable<void> {
     return this.bookingsUrl$.pipe(
-      concatMap((url) => this.http.delete<Response>(url, { params: { id } }))
+      concatMap((url) => this.http.delete<void>(url, { params: { id } }))
     );
   }
 

--- a/angular/src/app/services/booking/booking.service.ts
+++ b/angular/src/app/services/booking/booking.service.ts
@@ -45,7 +45,8 @@ export class BookingService {
    */
   delete(id: string): Observable<void> {
     return this.bookingsUrl$.pipe(
-      concatMap((url) => this.http.delete<void>(url, { params: { id } }))
+      map((url) => url.concat(`/${id}`)),
+      concatMap((url) => this.http.delete<void>(url))
     );
   }
 
@@ -55,8 +56,10 @@ export class BookingService {
    * @param id string
    */
   get(id?: string): Observable<Booking[]> {
-    const options = id ? { params: new HttpParams().set('id', id) } : {};
-    return this.bookingsUrl$.pipe(concatMap((url) => this.http.get<Booking[]>(url, options)));
+    return this.bookingsUrl$.pipe(
+      map((url) => (id ? url.concat(`/${id}`) : url)),
+      concatMap((url) => this.http.get<Booking[]>(url))
+    );
   }
 
   /**

--- a/angular/src/app/services/booking/booking.service.ts
+++ b/angular/src/app/services/booking/booking.service.ts
@@ -64,8 +64,8 @@ export class BookingService {
    *
    * @param booking Booking
    */
-  post(booking: Booking): Observable<boolean> {
-    return this.bookingsUrl$.pipe(concatMap((url) => this.http.post<boolean>(url, booking)));
+  post(booking: Booking): Observable<Booking> {
+    return this.bookingsUrl$.pipe(concatMap((url) => this.http.post<Booking>(url, booking)));
   }
 
   /**

--- a/angular/src/app/services/booking/booking.service.ts
+++ b/angular/src/app/services/booking/booking.service.ts
@@ -43,9 +43,9 @@ export class BookingService {
    *
    * @param id string
    */
-  delete(id: string): Observable<boolean> {
+  delete(id: string): Observable<Response> {
     return this.bookingsUrl$.pipe(
-      concatMap((url) => this.http.delete<boolean>(url, { params: { id } }))
+      concatMap((url) => this.http.delete<Response>(url, { params: { id } }))
     );
   }
 

--- a/angular/src/app/services/lodging/lodging.service.spec.ts
+++ b/angular/src/app/services/lodging/lodging.service.spec.ts
@@ -103,7 +103,7 @@ describe('LodgingService', () => {
     let req: TestRequest;
 
     service.delete('0').subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(service.delete).toHaveBeenCalled();
     });
 
     tick();

--- a/angular/src/app/services/lodging/lodging.service.spec.ts
+++ b/angular/src/app/services/lodging/lodging.service.spec.ts
@@ -151,13 +151,13 @@ describe('LodgingService', () => {
     let req: TestRequest;
 
     service.post(lodgingMock[0]).subscribe((res) => {
-      expect(JSON.parse(res.toString())).toBeTrue();
+      expect(res).toEqual(lodgingMock[0]);
     });
 
     tick();
 
     req = httpTestingController.expectOne('test');
-    req.flush(JSON.stringify(true));
+    req.flush(lodgingMock[0]);
   }));
 
   it('should make httpPut request', fakeAsync(() => {

--- a/angular/src/app/services/lodging/lodging.service.spec.ts
+++ b/angular/src/app/services/lodging/lodging.service.spec.ts
@@ -106,7 +106,7 @@ describe('LodgingService', () => {
 
     tick();
 
-    req = httpTestingController.expectOne('test?id=0');
+    req = httpTestingController.expectOne('test/0');
     req.flush(JSON.stringify(true));
   }));
 

--- a/angular/src/app/services/lodging/lodging.service.spec.ts
+++ b/angular/src/app/services/lodging/lodging.service.spec.ts
@@ -102,9 +102,7 @@ describe('LodgingService', () => {
   it('should make httpDelete request', fakeAsync(() => {
     let req: TestRequest;
 
-    service.delete('0').subscribe((res) => {
-      expect(service.delete).toHaveBeenCalled();
-    });
+    service.delete('0').subscribe();
 
     tick();
 

--- a/angular/src/app/services/lodging/lodging.service.spec.ts
+++ b/angular/src/app/services/lodging/lodging.service.spec.ts
@@ -107,7 +107,7 @@ describe('LodgingService', () => {
     tick();
 
     req = httpTestingController.expectOne('test/0');
-    req.flush(JSON.stringify(true));
+    req.flush(null);
   }));
 
   it('should make httpGet request', fakeAsync(() => {

--- a/angular/src/app/services/lodging/lodging.service.ts
+++ b/angular/src/app/services/lodging/lodging.service.ts
@@ -51,9 +51,9 @@ export class LodgingService {
    *
    * @param id string
    */
-  delete(id: string): Observable<Response> {
+  delete(id: string): Observable<void> {
     return this.lodgingsUrl$.pipe(
-      concatMap((url) => this.http.delete<Response>(url, { params: { id } }))
+      concatMap((url) => this.http.delete<void>(url, { params: { id } }))
     );
   }
 

--- a/angular/src/app/services/lodging/lodging.service.ts
+++ b/angular/src/app/services/lodging/lodging.service.ts
@@ -51,9 +51,9 @@ export class LodgingService {
    *
    * @param id string
    */
-  delete(id: string): Observable<boolean> {
+  delete(id: string): Observable<Response> {
     return this.lodgingsUrl$.pipe(
-      concatMap((url) => this.http.delete<boolean>(url, { params: { id } }))
+      concatMap((url) => this.http.delete<Response>(url, { params: { id } }))
     );
   }
 

--- a/angular/src/app/services/lodging/lodging.service.ts
+++ b/angular/src/app/services/lodging/lodging.service.ts
@@ -81,8 +81,8 @@ export class LodgingService {
    *
    * @param lodging Lodging
    */
-  post(lodging: Lodging): Observable<boolean> {
-    return this.lodgingsUrl$.pipe(concatMap((url) => this.http.post<boolean>(url, lodging)));
+  post(lodging: Lodging): Observable<Lodging> {
+    return this.lodgingsUrl$.pipe(concatMap((url) => this.http.post<Lodging>(url, lodging)));
   }
 
   /**

--- a/angular/src/app/services/lodging/lodging.service.ts
+++ b/angular/src/app/services/lodging/lodging.service.ts
@@ -53,7 +53,8 @@ export class LodgingService {
    */
   delete(id: string): Observable<void> {
     return this.lodgingsUrl$.pipe(
-      concatMap((url) => this.http.delete<void>(url, { params: { id } }))
+      map((url) => url.concat(`/${id}`)),
+      concatMap((url) => this.http.delete<void>(url))
     );
   }
 
@@ -73,7 +74,10 @@ export class LodgingService {
    * @param id string
    */
   getById(id: string): Observable<Lodging> {
-    return this.lodgingsUrl$.pipe(concatMap((url) => this.http.get<Lodging>(`${url}/${id}`)));
+    return this.lodgingsUrl$.pipe(
+      map((url) => url.concat(`/${id}`)),
+      concatMap((url) => this.http.get<Lodging>(url))
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #76 

Post and Delete methods in services are currently returning Observable\<boolean\>. Posts should return an observable of their model, and delete should return an observable of void.

Additionally, the id should be included in the url using route params, i.e. account/1, rather than query string params, i.e. account?id=1.