### PR TITLE
New on changes

### DIFF
--- a/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
+++ b/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
@@ -13,7 +13,6 @@ export class LodgingDetailsComponent implements OnInit {
    * fields used in this component
    */
   lodging: Lodging | null = null;
-  update: Subscription = new Subscription();
 
   /**
    * provide activated route to get route parameters and lodging service to get lodging
@@ -30,9 +29,6 @@ export class LodgingDetailsComponent implements OnInit {
    */
   ngOnInit(): void {
     this.getLodgingById();
-
-    const timer = interval(1000);
-    this.update = timer.subscribe(x => this.getLodgingById());
   }
 
   /**
@@ -47,10 +43,5 @@ export class LodgingDetailsComponent implements OnInit {
         });
       }
     });
-  }
-
-  // Unsubscribes from the observable and stops the update interval
-  ngOnDestroy(){
-    this.update.unsubscribe();
   }
 }

--- a/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
+++ b/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
@@ -13,6 +13,7 @@ export class LodgingDetailsComponent implements OnInit {
    * fields used in this component
    */
   lodging: Lodging | null = null;
+  update: Subscription = new Subscription();
 
   /**
    * provide activated route to get route parameters and lodging service to get lodging
@@ -29,6 +30,9 @@ export class LodgingDetailsComponent implements OnInit {
    */
   ngOnInit(): void {
     this.getLodgingById();
+
+    const timer = interval(1000);
+    this.update = timer.subscribe(x => this.getLodgingById());
   }
 
   /**

--- a/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
+++ b/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
@@ -48,4 +48,9 @@ export class LodgingDetailsComponent implements OnInit {
       }
     });
   }
+
+  // Unsubscribes from the observable and stops the update interval
+  ngOnDestroy(){
+    this.update.unsubscribe();
+  }
 }

--- a/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
+++ b/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Lodging } from '../../../data/lodging.model';
 import { ActivatedRoute } from '@angular/router';
 import { LodgingService } from '../../../services/lodging/lodging.service';
+import { Subscription, interval } from 'rxjs';
 
 @Component({
   selector: 'uic-lodging-details',
@@ -12,6 +13,7 @@ export class LodgingDetailsComponent implements OnInit {
    * fields used in this component
    */
   lodging: Lodging | null = null;
+  update: Subscription = new Subscription();
 
   /**
    * provide activated route to get route parameters and lodging service to get lodging
@@ -28,6 +30,9 @@ export class LodgingDetailsComponent implements OnInit {
    */
   ngOnInit(): void {
     this.getLodgingById();
+
+    const timer = interval(1000);
+    this.update = timer.subscribe(x => this.getLodgingById());
   }
 
   /**

--- a/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
+++ b/angular/src/app/modules/lodging/lodging-details/lodging-details.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { Lodging } from '../../../data/lodging.model';
 import { ActivatedRoute } from '@angular/router';
 import { LodgingService } from '../../../services/lodging/lodging.service';
-import { Subscription, interval } from 'rxjs';
 
 @Component({
   selector: 'uic-lodging-details',

--- a/angular/src/app/modules/lodging/rental/rental.component.spec.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.spec.ts
@@ -88,4 +88,21 @@ describe('RentalComponent', () => {
     expect(headerRow.cells[0].innerHTML).toContain('Site');
     expect(headerRow.cells[2].innerHTML).toContain('Sites Available');
   });
+
+  it('should add rental', () => {
+    const rental = {
+      id: '5',
+      name: 'Rental5',
+      occupancy: 2,
+      type: 'tent',
+      status: 'available',
+      price: 100,
+    };
+    const newRentals = rentals;
+    newRentals.push(rental);
+    component.rentals = newRentals;
+    component.ngOnChanges();
+    expect(component.availabilityCount.get('tent')).toEqual(3);
+  });
+
 });

--- a/angular/src/app/modules/lodging/rental/rental.component.spec.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.spec.ts
@@ -112,4 +112,5 @@ describe('RentalComponent', () => {
     component.ngOnChanges();
     expect(component.availabilityCount.get('tent')).toEqual(1);
   });
+  
 });

--- a/angular/src/app/modules/lodging/rental/rental.component.spec.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.spec.ts
@@ -112,5 +112,4 @@ describe('RentalComponent', () => {
     component.ngOnChanges();
     expect(component.availabilityCount.get('tent')).toEqual(1);
   });
-
 });

--- a/angular/src/app/modules/lodging/rental/rental.component.spec.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.spec.ts
@@ -98,7 +98,7 @@ describe('RentalComponent', () => {
       status: 'available',
       price: 100,
     };
-    const newRentals = rentals;
+    const newRentals = <Rental[]> JSON.parse(JSON.stringify(rentals));
     newRentals.push(rental);
     component.rentals = newRentals;
     component.ngOnChanges();

--- a/angular/src/app/modules/lodging/rental/rental.component.spec.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.spec.ts
@@ -89,7 +89,7 @@ describe('RentalComponent', () => {
     expect(headerRow.cells[2].innerHTML).toContain('Sites Available');
   });
 
-  it('should add rental', () => {
+  it('should add and remove rental', () => {
     const rental = {
       id: '5',
       name: 'Rental5',
@@ -98,19 +98,16 @@ describe('RentalComponent', () => {
       status: 'available',
       price: 100,
     };
-    const newRentals = JSON.parse(JSON.stringify(rentals)) as Rental[];
-    newRentals.push(rental);
-    component.rentals = newRentals;
+
+    // Adds Rental
+    rentals.push(rental);
+    component.rentals = rentals;
     component.ngOnChanges();
     expect(component.availabilityCount.get('tent')).toEqual(3);
-  });
 
-  it('should remove rental', () => {
-    const newRentals = JSON.parse(JSON.stringify(rentals)) as Rental[];
-    newRentals.splice(0, 1);
-    component.rentals = newRentals;
+    // Removes Rental
+    component.rentals.splice(4, 1);
     component.ngOnChanges();
-    expect(component.availabilityCount.get('tent')).toEqual(1);
+    expect(component.availabilityCount.get('tent')).toEqual(2);
   });
-  
 });

--- a/angular/src/app/modules/lodging/rental/rental.component.spec.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.spec.ts
@@ -98,11 +98,19 @@ describe('RentalComponent', () => {
       status: 'available',
       price: 100,
     };
-    const newRentals = <Rental[]> JSON.parse(JSON.stringify(rentals));
+    const newRentals = JSON.parse(JSON.stringify(rentals)) as Rental[];
     newRentals.push(rental);
     component.rentals = newRentals;
     component.ngOnChanges();
     expect(component.availabilityCount.get('tent')).toEqual(3);
+  });
+
+  it('should remove rental', () => {
+    const newRentals = JSON.parse(JSON.stringify(rentals)) as Rental[];
+    newRentals.splice(0, 1);
+    component.rentals = newRentals;
+    component.ngOnChanges();
+    expect(component.availabilityCount.get('tent')).toEqual(1);
   });
 
 });

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -1,7 +1,7 @@
 /**
  * importing the necessary modules, services and models.
  */
-import { Component, OnInit, Input, SimpleChanges } from '@angular/core';
+import { Component, OnInit, Input, SimpleChanges, OnChanges } from '@angular/core';
 import { Rental } from '../../../data/rental.model';
 
 /**
@@ -16,7 +16,7 @@ import { Rental } from '../../../data/rental.model';
 /**
  * This class represents the Rental component
  */
-export class RentalComponent implements OnInit {
+export class RentalComponent implements OnInit, OnChanges {
   /**
    * rentals taken from the lodging-details lodging.rentals
    */
@@ -35,7 +35,7 @@ export class RentalComponent implements OnInit {
   }
 
   // Whenever changes are made in the @Input, rerun setRentalTypes again to update the information
-  ngOnChanges(changes?: SimpleChanges){
+  ngOnChanges(changes?: SimpleChanges): void{
     this.setRentalTypes(this.rentals);
   }
 

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -1,7 +1,11 @@
 /**
  * importing the necessary modules, services and models.
  */
+<<<<<<< HEAD
 import { Component, OnInit, Input, SimpleChanges, OnChanges } from '@angular/core';
+=======
+import { Component, OnInit, Input, SimpleChanges } from '@angular/core';
+>>>>>>> installed puppeteer for testing, added OnChanges to rental component and interval to lodging component
 import { Rental } from '../../../data/rental.model';
 
 /**

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -35,7 +35,7 @@ export class RentalComponent implements OnInit, OnChanges {
   }
 
   // Whenever changes are made in the @Input, rerun setRentalTypes again to update the information
-  ngOnChanges(changes?: SimpleChanges): void{
+  ngOnChanges(changes?: SimpleChanges): void {
     this.setRentalTypes(this.rentals);
   }
 
@@ -61,5 +61,4 @@ export class RentalComponent implements OnInit, OnChanges {
       this.availabilityCount.set(rental.type, count);
     }
   }
-
 }

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -36,9 +36,7 @@ export class RentalComponent implements OnInit {
 
   // Whenever changes are made in the @Input, rerun setRentalTypes again to update the information
   ngOnChanges(changes: SimpleChanges){
-
     this.setRentalTypes(this.rentals);
-
   }
 
   /**
@@ -49,6 +47,8 @@ export class RentalComponent implements OnInit {
     // check to see if a rental has the same type as one that's already in the rentalTypes
     // only keep track of the rental types that are unique
     // increment the availability count for each rental in rentals if they are available
+    this.availabilityCount.clear();
+    this.rentalTypes = [];
     for (const rental of rentals) {
       let count = this.availabilityCount.get(rental.type);
       if (count === undefined) {
@@ -61,4 +61,5 @@ export class RentalComponent implements OnInit {
       this.availabilityCount.set(rental.type, count);
     }
   }
+
 }

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -34,7 +34,7 @@ export class RentalComponent implements OnInit {
     this.setRentalTypes(this.rentals);
   }
 
-  //Whenever changes are made in the @Input, reun setRentalTypes again to update the information
+  // Whenever changes are made in the @Input, rerun setRentalTypes again to update the information
   ngOnChanges(changes: SimpleChanges){
 
     this.setRentalTypes(this.rentals);

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -47,6 +47,7 @@ export class RentalComponent implements OnInit, OnChanges {
     // check to see if a rental has the same type as one that's already in the rentalTypes
     // only keep track of the rental types that are unique
     // increment the availability count for each rental in rentals if they are available
+    // clears rentaltypes and availability count every time it's called
     this.availabilityCount.clear();
     this.rentalTypes = [];
     for (const rental of rentals) {

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -1,7 +1,7 @@
 /**
  * importing the necessary modules, services and models.
  */
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, SimpleChanges } from '@angular/core';
 import { Rental } from '../../../data/rental.model';
 
 /**
@@ -32,6 +32,13 @@ export class RentalComponent implements OnInit {
 
   ngOnInit(): void {
     this.setRentalTypes(this.rentals);
+  }
+
+  //Whenever changes are made in the @Input, reun setRentalTypes again to update the information
+  ngOnChanges(changes: SimpleChanges){
+
+    this.setRentalTypes(this.rentals);
+
   }
 
   /**

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -35,7 +35,7 @@ export class RentalComponent implements OnInit {
   }
 
   // Whenever changes are made in the @Input, rerun setRentalTypes again to update the information
-  ngOnChanges(changes: SimpleChanges){
+  ngOnChanges(changes?: SimpleChanges){
     this.setRentalTypes(this.rentals);
   }
 

--- a/angular/src/app/modules/lodging/rental/rental.component.ts
+++ b/angular/src/app/modules/lodging/rental/rental.component.ts
@@ -1,11 +1,7 @@
 /**
  * importing the necessary modules, services and models.
  */
-<<<<<<< HEAD
 import { Component, OnInit, Input, SimpleChanges, OnChanges } from '@angular/core';
-=======
-import { Component, OnInit, Input, SimpleChanges } from '@angular/core';
->>>>>>> installed puppeteer for testing, added OnChanges to rental component and interval to lodging component
 import { Rental } from '../../../data/rental.model';
 
 /**


### PR DESCRIPTION
fixes #63 

Because the rental component takes input from its parent component, Lodging-Details, OnChanges makes more sense and is better practice. The unit tests would have to change accordingly.

Right now, if a reservation is made, it will not update accordingly.

Create an OnChanges method (which will be called in OnInit) to update the rentals which have had availability changes.

Change rental listing/ availability to be real time instead of on refresh changes.