### PR TITLE
Get and Store Image (remove placeholder)

### DIFF
--- a/angular/src/app.config.json
+++ b/angular/src/app.config.json
@@ -20,7 +20,8 @@
       "uri": {
         "lodging": "lodging",
         "rental": "rental",
-        "review": "review"
+        "review": "review",
+        "image": "image"
       }
     },
     "monitoring": "https://ec61288c429544a6ad850b94de25004a@o388320.ingest.sentry.io/5229046"

--- a/angular/src/app.config.local.json
+++ b/angular/src/app.config.local.json
@@ -20,7 +20,8 @@
       "uri": {
         "lodging": "lodging",
         "rental": "rental",
-        "review": "review"
+        "review": "review",
+        "image": "image"
       }
     },
     "monitoring": "https://ec61288c429544a6ad850b94de25004a@o388320.ingest.sentry.io/5229046"

--- a/angular/src/app/data/config.model.ts
+++ b/angular/src/app/data/config.model.ts
@@ -31,6 +31,7 @@ export interface Config {
         lodging: string;
         rental: string;
         review: string;
+        image: string;
       };
     };
     monitoring: string;

--- a/angular/src/app/services/lodging/lodging.service.ts
+++ b/angular/src/app/services/lodging/lodging.service.ts
@@ -12,7 +12,7 @@ export class LodgingService {
   private readonly lodgingsUrl$: Observable<string>;
   private readonly rentalsUrl$: Observable<string>;
   private readonly reviewsUrl$: Observable<string>;
-
+  private readonly imageUrl$: Observable<string>;
   /**
    * Represents the _Lodging Service_ `constructor` method
    *
@@ -29,6 +29,9 @@ export class LodgingService {
     );
     this.reviewsUrl$ = config$.pipe(
       map((cfg) => `${cfg.api.lodging.base}${cfg.api.lodging.uri.review}`)
+    );
+    this.imageUrl$ = config$.pipe(
+      map((cfg) => `${cfg.api.lodging.base}${cfg.api.lodging.uri.image}`)
     );
   }
 


### PR DESCRIPTION
closes #61 The lodging model needs an image property to display the pictures of the actual campground. This property may need to be an array because there are multiple placeholders for different images in the lodging details component.

Leverage unsplash.com, pixabay.com, or pexels (or submit a request to use any other CC image API) to provide images.

ImageController in lodging to interface with API to get images. 
Leverage blob storage to save images.
Lodging model in API needs image collection URLs (to pull images from storage)