### PR TITLE
Log HTTP Errors on Angular Services

### DIFF
--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -5,7 +5,7 @@ import { catchError, concatMap, map } from 'rxjs/operators';
 import { ConfigService } from '../config/config.service';
 import { Account } from '../../data/account.model';
 import { PostPayment } from '../../data/payment.model';
-import { MonitoringService } from 'services/monitoring/monitoring.service';
+import { MonitoringService } from '../monitoring/monitoring.service';
 
 @Injectable({
   providedIn: 'root',
@@ -15,7 +15,6 @@ export class AccountService {
   private readonly addressesUrl$: Observable<string>;
   private readonly profilesUrl$: Observable<string>;
   private readonly paymentsUrl$: Observable<string>;
-  private readonly monitoring$: MonitoringService;
 
   /**
    * Represents the _Account Service_ `constructor` method
@@ -26,10 +25,9 @@ export class AccountService {
   constructor(
     config: ConfigService,
     private readonly http: HttpClient,
-    monitor: MonitoringService
+    private readonly monitoring: MonitoringService
   ) {
     const config$ = config.get();
-    this.monitoring$ = monitor;
 
     this.accountsUrl$ = config$.pipe(
       map((cfg) => `${cfg.api.account.base}${cfg.api.account.uri.account}`)
@@ -55,8 +53,8 @@ export class AccountService {
       map((url) => url.concat(`/${id}`)),
       concatMap((url) =>
         this.http.delete<void>(url).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Account Service Error');
           })
         )
@@ -74,8 +72,8 @@ export class AccountService {
       map((url) => url.concat(`/${id}`)),
       concatMap((url) =>
         this.http.get<Account>(url).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Account Service Error');
           })
         )
@@ -92,8 +90,8 @@ export class AccountService {
     return this.accountsUrl$.pipe(
       concatMap((url) =>
         this.http.post<Account>(url, account).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Account Service Error');
           })
         )
@@ -110,8 +108,8 @@ export class AccountService {
     return this.accountsUrl$.pipe(
       concatMap((url) =>
         this.http.put<Account>(url, account).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Account Service Error');
           })
         )
@@ -128,8 +126,8 @@ export class AccountService {
     return this.paymentsUrl$.pipe(
       concatMap((url) =>
         this.http.post<PostPayment>(url, payment).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Account Service Error');
           })
         )

--- a/angular/src/app/services/lodging/lodging.service.ts
+++ b/angular/src/app/services/lodging/lodging.service.ts
@@ -5,7 +5,7 @@ import { catchError, concatMap, map } from 'rxjs/operators';
 import { ConfigService } from '../config/config.service';
 import { Lodging } from '../../data/lodging.model';
 import { Filter } from '../../data/filter.model';
-import { MonitoringService } from 'services/monitoring/monitoring.service';
+import { MonitoringService } from '../monitoring/monitoring.service';
 
 @Injectable({
   providedIn: 'root',
@@ -14,7 +14,6 @@ export class LodgingService {
   private readonly lodgingsUrl$: Observable<string>;
   private readonly rentalsUrl$: Observable<string>;
   private readonly reviewsUrl$: Observable<string>;
-  private readonly monitoring$: MonitoringService;
 
   /**
    * Represents the _Lodging Service_ `constructor` method
@@ -25,10 +24,9 @@ export class LodgingService {
   constructor(
     config: ConfigService,
     private readonly http: HttpClient,
-    monitor: MonitoringService
+    private readonly monitoring: MonitoringService
   ) {
     const config$ = config.get();
-    this.monitoring$ = monitor;
 
     this.lodgingsUrl$ = config$.pipe(
       map((cfg) => `${cfg.api.lodging.base}${cfg.api.lodging.uri.lodging}`)
@@ -51,8 +49,8 @@ export class LodgingService {
       map((url) => url.concat(`/${id}`)),
       concatMap((url) =>
         this.http.delete<void>(url).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Lodging Service Error');
           })
         )
@@ -70,8 +68,8 @@ export class LodgingService {
       return this.lodgingsUrl$.pipe(
         concatMap((url) =>
           this.http.get<Lodging[]>(url).pipe(
-            catchError((error) => {
-              this.monitoring$.handleError(error);
+            catchError((err) => {
+              this.monitoring.handleError(err);
               return throwError('Lodging Service Error');
             })
           )
@@ -84,8 +82,8 @@ export class LodgingService {
           this.http
             .get<Lodging[]>(`${url}/available`, { params })
             .pipe(
-              catchError((error) => {
-                this.monitoring$.handleError(error);
+              catchError((err) => {
+                this.monitoring.handleError(err);
                 return throwError('Lodging Service Error');
               })
             )
@@ -104,8 +102,8 @@ export class LodgingService {
       map((url) => url.concat(`/${id}`)),
       concatMap((url) =>
         this.http.get<Lodging>(url).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Lodging Service Error');
           })
         )
@@ -122,8 +120,8 @@ export class LodgingService {
     return this.lodgingsUrl$.pipe(
       concatMap((url) =>
         this.http.post<Lodging>(url, lodging).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Lodging Service Error');
           })
         )
@@ -140,8 +138,8 @@ export class LodgingService {
     return this.lodgingsUrl$.pipe(
       concatMap((url) =>
         this.http.put<Lodging>(url, lodging).pipe(
-          catchError((error) => {
-            this.monitoring$.handleError(error);
+          catchError((err) => {
+            this.monitoring.handleError(err);
             return throwError('Lodging Service Error');
           })
         )


### PR DESCRIPTION
When the service unsuccessfully calls an api, the error should be caught and sent to Sentry to be logged. It should also display the detailed error in the console.