### PR TITLE
Removing Hard coded account id

### DIFF
--- a/angular/src/app/data/account.model.ts
+++ b/angular/src/app/data/account.model.ts
@@ -7,6 +7,7 @@ import { Profile } from './profile.model';
  *
  * ```yaml
  * id: string;
+ * email: string;
  * address: Address;
  * payments: Payment[];
  * profiles: Profile[];
@@ -16,6 +17,8 @@ export interface Account {
   id: string;
   /** address for the owner of the account */
   address: Address;
+  /** the email associated with the account */
+  email : string;
   /** stored payment methods */
   payments: Payment[];
   /** people the account owner can book a site with */

--- a/angular/src/app/modules/account/account/account.component.spec.ts
+++ b/angular/src/app/modules/account/account/account.component.spec.ts
@@ -12,6 +12,7 @@ describe('AccountComponent', () => {
     get(): Observable<Account> {
       const account: Account = {
         id: '',
+        email: '',
         address: {
           id: '',
           city: '',

--- a/angular/src/app/modules/account/account/account.component.ts
+++ b/angular/src/app/modules/account/account/account.component.ts
@@ -1,4 +1,5 @@
 import { Component, Inject } from '@angular/core';
+import { EmailValidator } from '@angular/forms';
 import { Account } from 'data/account.model';
 import { Address } from 'data/address.model';
 import { Booking } from 'data/booking.model';
@@ -25,18 +26,22 @@ export class AccountComponent {
   reviews$: Observable<Review[]>;
 
   private readonly id = '-1';
-  accountId = this.id;
-
+  cookie = document.cookie.split("; ").find(row => row.startsWith("email"));
+  email = "";//this is the email taken from the token defaults to empty if it doesnt exist for now ask fred about it later
   constructor(
     private readonly accountService: AccountService,
     private readonly bookingService: BookingService,
     @Inject(ACCOUNT_EDITING_SERVICE)
     editingService: GenericEditingService<Partial<Account>>
   ) {
-    this.account$ = this.accountService.get(this.id);
-
+    if(this.cookie != null)
+    {
+      this.email = this.cookie.split("=")[1];
+    }
+    this.account$ = this.accountService.get(this.email);
     this.bookings$ = this.bookingService.get(this.id);
-
+    
+    
     this.reviews$ = of([
       // Not yet implemented
     ]);
@@ -48,6 +53,7 @@ export class AccountComponent {
     this.account$.subscribe((e) => editingService.update(e));
     // Register function for Payload release from editing service
     editingService.payloadEmitter.subscribe((val) => this.update(val as Account));
+    
   }
 
   /**

--- a/angular/src/app/modules/account/address/address.component.spec.ts
+++ b/angular/src/app/modules/account/address/address.component.spec.ts
@@ -11,6 +11,7 @@ describe('AddressComponent', () => {
     get(): Observable<Account> {
       const account: Account = {
         id: '',
+        email: '',
         address: {
           id: '',
           city: '',

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -15,6 +15,7 @@ import { PostPayment } from 'src/app/data/payment.model';
 describe('AccountService', () => {
   const accountMock: Account = {
     id: '0',
+    email: 'testemail@something.com',
     address: {
       id: 'string',
       city: 'string',
@@ -36,7 +37,7 @@ describe('AccountService', () => {
       {
         type: 'adult',
         id: 'string',
-        email: 'string',
+        email: 'testemail@something.com',
         familyName: 'string',
         givenName: 'string',
         phone: 'string',
@@ -108,13 +109,13 @@ describe('AccountService', () => {
   it('should make httpGet request', fakeAsync(() => {
     let req: TestRequest;
 
-    service.get('0').subscribe((res) => {
+    service.get('testemail@something.com').subscribe((res) => {
       expect(res).toEqual(accountMock);
     });
 
     tick();
 
-    req = httpTestingController.expectOne('test/0');
+    req = httpTestingController.expectOne('test/testemail@something.com');
     req.flush(accountMock);
   }));
 

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -60,6 +60,18 @@ export class AccountService {
       concatMap((url) => this.http.get<Account>(url))
     );
   }
+  /**
+   * Represents the _Account Service_ `getbyemail` method
+   *
+   * @param email string
+   */
+  getByEmail(email: string): Observable<Account> {
+    return this.profilesUrl$.pipe(
+      map((url) => url.concat(`/email/${email}`)),
+      concatMap((url) => this.http.get<Account>(url))
+    );
+  }
+
 
   /**
    * Represents the _Account Service_ `post` method

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -72,7 +72,6 @@ export class AccountService {
     );
   }
 
-
   /**
    * Represents the _Account Service_ `post` method
    *

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -52,22 +52,11 @@ export class AccountService {
   /**
    * Represents the _Account Service_ `get` method
    *
-   * @param id string
-   */
-  get(id: string): Observable<Account> {
-    return this.accountsUrl$.pipe(
-      map((url) => url.concat(`/${id}`)),
-      concatMap((url) => this.http.get<Account>(url))
-    );
-  }
-  /**
-   * Represents the _Account Service_ `getbyemail` method
-   *
    * @param email string
    */
-  getByEmail(email: string): Observable<Account> {
-    return this.profilesUrl$.pipe(
-      map((url) => url.concat(`/email/${email}`)),
+  get(email: string): Observable<Account> {
+    return this.accountsUrl$.pipe(
+      map((url) => url.concat(`/${email}`)),
       concatMap((url) => this.http.get<Account>(url))
     );
   }

--- a/angular/src/app/services/editable/generic-editing.service.spec.ts
+++ b/angular/src/app/services/editable/generic-editing.service.spec.ts
@@ -5,6 +5,7 @@ describe('AccountEditingService', () => {
   let service = new GenericEditingService<Partial<Account>>();
   const account: Account = {
     id: '',
+    email: '',
     address: {
       id: '',
       city: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Creating a method in the service to retrieve account information by passing an email instead of an id so that we can use the email provided by Okta to load the correct account.
fixes #108