### PR TITLE
Issue/108

### DIFF
--- a/angular/src/app/data/account.model.ts
+++ b/angular/src/app/data/account.model.ts
@@ -7,6 +7,7 @@ import { Profile } from './profile.model';
  *
  * ```yaml
  * id: string;
+ * email: string;
  * address: Address;
  * payments: Payment[];
  * profiles: Profile[];
@@ -17,9 +18,11 @@ export interface Account {
   /** address for the owner of the account */
   address: Address;
 
+  name : string;
+
   email: string;
   /** stored payment methods */
-  payments: Payment[];
+  payments: Payment[] ;
   /** people the account owner can book a site with */
-  profiles: Profile[];
+  profiles: Profile[] ;
 }

--- a/angular/src/app/data/account.model.ts
+++ b/angular/src/app/data/account.model.ts
@@ -16,6 +16,8 @@ export interface Account {
   id: string;
   /** address for the owner of the account */
   address: Address;
+
+  email: string;
   /** stored payment methods */
   payments: Payment[];
   /** people the account owner can book a site with */

--- a/angular/src/app/modules/account/account/account.component.spec.ts
+++ b/angular/src/app/modules/account/account/account.component.spec.ts
@@ -12,8 +12,10 @@ describe('AccountComponent', () => {
     get(): Observable<Account> {
       const account: Account = {
         id: '',
+        email : '',
         address: {
           id: '',
+          
           city: '',
           country: '',
           postalCode: '',

--- a/angular/src/app/modules/account/account/account.component.spec.ts
+++ b/angular/src/app/modules/account/account/account.component.spec.ts
@@ -13,6 +13,7 @@ describe('AccountComponent', () => {
       const account: Account = {
         id: '',
         email : '',
+        name : '',
         address: {
           id: '',
           

--- a/angular/src/app/modules/account/account/account.component.ts
+++ b/angular/src/app/modules/account/account/account.component.ts
@@ -1,4 +1,5 @@
 import { analyzeAndValidateNgModules } from '@angular/compiler';
+import { nullSafeIsEquivalent } from '@angular/compiler/src/output/output_ast';
 import { Component, Inject } from '@angular/core';
 import { Account } from 'data/account.model';
 import { Address } from 'data/address.model';
@@ -28,21 +29,43 @@ export class AccountComponent {
   private readonly id = '-1';
   accountId = this.id;
   email : string;
+  name: string;
   
-  
+
+
   constructor(
     private readonly accountService: AccountService,
     private readonly bookingService: BookingService,
     @Inject(ACCOUNT_EDITING_SERVICE)
     editingService: GenericEditingService<Partial<Account>>
   ) {
-   
+  
+    //gets token from localstorage
     const OktaToken = localStorage.getItem("okta-token-storage");
     const OkTokenObj = JSON.parse(OktaToken as string);
     this.email = OkTokenObj.idToken.claims.email;
-    console.log(this.email);
-    this.account$ = this.accountService.get(this.id);
-   // this.account$ = this.accountService.getEmail(this.email);
+    this.name = OkTokenObj.idToken.claims.name;
+    //returns user associated with the email parsed from the token, currently hard coding email for testing purposes.
+    this.account$ = this.accountService.getEmail("Test@test.com");
+    //code for actual production purposes, when posting function is completed.
+    //this.account$ = this.accountService.getEmail(this.email);
+ 
+    /*TODO: 
+     let account = <Account>{ 
+       id : "-2",
+       email : this.email,
+       name : this.name,
+
+     };
+     this.accountService.post(account); */
+   
+ 
+    
+
+
+
+
+    
 
     // TODO: get only the bookings of this account
     this.bookings$ = this.bookingService.get();
@@ -52,7 +75,8 @@ export class AccountComponent {
     ]);
     this.address$ = this.account$.pipe(map((account) => account.address));
     this.payments$ = this.account$.pipe(map((account) => account.payments));
-    this.profiles$ = this.account$.pipe(map((account) => account.profiles));  
+    this.profiles$ = this.account$.pipe(map((account) => account.profiles)); 
+     
 
     // Pass initial model to editingService which acts as model for overwriting data coming in
     this.account$.subscribe((e) => editingService.update(e));

--- a/angular/src/app/modules/account/account/account.component.ts
+++ b/angular/src/app/modules/account/account/account.component.ts
@@ -39,10 +39,10 @@ export class AccountComponent {
    
     const OktaToken = localStorage.getItem("okta-token-storage");
     const OkTokenObj = JSON.parse(OktaToken as string);
-    this.email = (OkTokenObj.idToken.claims.email);
+    this.email = OkTokenObj.idToken.claims.email;
     console.log(this.email);
-    //this.account$ = this.accountService.get(this.id);
-    this.account$ = this.accountService.getEmail(this.email);
+    this.account$ = this.accountService.get(this.id);
+   // this.account$ = this.accountService.getEmail(this.email);
 
     // TODO: get only the bookings of this account
     this.bookings$ = this.bookingService.get();
@@ -53,7 +53,7 @@ export class AccountComponent {
     this.address$ = this.account$.pipe(map((account) => account.address));
     this.payments$ = this.account$.pipe(map((account) => account.payments));
     this.profiles$ = this.account$.pipe(map((account) => account.profiles));  
-    
+
     // Pass initial model to editingService which acts as model for overwriting data coming in
     this.account$.subscribe((e) => editingService.update(e));
     // Register function for Payload release from editing service

--- a/angular/src/app/modules/account/account/account.component.ts
+++ b/angular/src/app/modules/account/account/account.component.ts
@@ -1,3 +1,4 @@
+import { analyzeAndValidateNgModules } from '@angular/compiler';
 import { Component, Inject } from '@angular/core';
 import { Account } from 'data/account.model';
 import { Address } from 'data/address.model';
@@ -5,6 +6,7 @@ import { Booking } from 'data/booking.model';
 import { Payment } from 'data/payment.model';
 import { Profile } from 'data/profile.model';
 import { Review } from 'data/review.model';
+import { stringify } from 'querystring';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AccountService } from 'services/account/account.service';
@@ -23,17 +25,24 @@ export class AccountComponent {
   payments$: Observable<Payment[]>;
   profiles$: Observable<Profile[]>;
   reviews$: Observable<Review[]>;
-
   private readonly id = '-1';
   accountId = this.id;
-
+  email : string;
+  
+  
   constructor(
     private readonly accountService: AccountService,
     private readonly bookingService: BookingService,
     @Inject(ACCOUNT_EDITING_SERVICE)
     editingService: GenericEditingService<Partial<Account>>
   ) {
-    this.account$ = this.accountService.get(this.id);
+   
+    const OktaToken = localStorage.getItem("okta-token-storage");
+    const OkTokenObj = JSON.parse(OktaToken as string);
+    this.email = (OkTokenObj.idToken.claims.email);
+    console.log(this.email);
+    //this.account$ = this.accountService.get(this.id);
+    this.account$ = this.accountService.getEmail(this.email);
 
     // TODO: get only the bookings of this account
     this.bookings$ = this.bookingService.get();
@@ -43,14 +52,15 @@ export class AccountComponent {
     ]);
     this.address$ = this.account$.pipe(map((account) => account.address));
     this.payments$ = this.account$.pipe(map((account) => account.payments));
-    this.profiles$ = this.account$.pipe(map((account) => account.profiles));
-
+    this.profiles$ = this.account$.pipe(map((account) => account.profiles));  
+    
     // Pass initial model to editingService which acts as model for overwriting data coming in
     this.account$.subscribe((e) => editingService.update(e));
     // Register function for Payload release from editing service
     editingService.payloadEmitter.subscribe((val) => this.update(val as Account));
   }
 
+  
   /**
    * Function registered to the editing service
    */

--- a/angular/src/app/services/account/account.service.spec.ts
+++ b/angular/src/app/services/account/account.service.spec.ts
@@ -15,6 +15,8 @@ import { PostPayment } from 'src/app/data/payment.model';
 describe('AccountService', () => {
   const accountMock: Account = {
     id: '0',
+    email: 'test',
+    name : '',
     address: {
       id: 'string',
       city: 'string',

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -37,6 +37,12 @@ export class AccountService {
     );
   }
 
+oktaToken(){
+
+}
+
+
+
   /**
    * Represents the _Account Service_ `delete` method
    *
@@ -79,6 +85,7 @@ export class AccountService {
    * @param account Account
    */
   post(account: Account): Observable<Account> {
+    console.log("posting..");
     return this.accountsUrl$.pipe(concatMap((url) => this.http.post<Account>(url, account)));
   }
 
@@ -88,7 +95,7 @@ export class AccountService {
    * @param account Account
    */
   put(account: Account): Observable<Account> {
-    return this.accountsUrl$.pipe(concatMap((url) => this.http.put<Account>(url, account)));
+    return this.accountsUrl$.pipe(map((url) => url.concat(`/${account.email}`)),concatMap((url) => this.http.put<Account>(url, account)));
   }
 
   /**

--- a/angular/src/app/services/account/account.service.ts
+++ b/angular/src/app/services/account/account.service.ts
@@ -61,6 +61,18 @@ export class AccountService {
     );
   }
 
+   /**
+   * Represents the _Account Service_ `getEmail` method
+   *
+   * @param email string
+   */
+  getEmail(email: string): Observable<Account> {
+    return this.accountsUrl$.pipe(
+      map((url) => url.concat(`/${email}`)),
+      concatMap((url) => this.http.get<Account>(url))
+    );
+  }
+
   /**
    * Represents the _Account Service_ `post` method
    *

--- a/angular/src/app/services/editable/generic-editing.service.spec.ts
+++ b/angular/src/app/services/editable/generic-editing.service.spec.ts
@@ -5,6 +5,8 @@ describe('AccountEditingService', () => {
   let service = new GenericEditingService<Partial<Account>>();
   const account: Account = {
     id: '',
+    email: '',
+    name : '',
     address: {
       id: '',
       city: '',


### PR DESCRIPTION
Okta account creation is decoupled from our internal db accounts. To resolve issue #108, we parsed through the auth token we got back from okta stored in localstorage to get the email and name, and then did a get request from the api using the email we gotten back from okta in order to couple local user info and okta user info. We weren't sure if that is the best way to integrate okta account data to our user model. We would like some clarification if that's the ideal way for okta integration. 