### PR TITLE
Fix spelling error in error component template

### DIFF
--- a/angular/src/app/modules/home/error/error.component.html
+++ b/angular/src/app/modules/home/error/error.component.html
@@ -3,7 +3,7 @@
     <div class="container">
       <p class="title is-1">RVTR Campground</p>
       <p class="subtitle is-3 is-italic">
-        what a mess... we will have this cleanup up momentarily.
+        what a mess... we will have this cleaned up up momentarily.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Changed "cleanup" to "cleaned up."

i.e.  cleaned up the error component.
